### PR TITLE
Notify about deprecation of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Run GitHub Actions Workflow Action
 
+:warning: **This project is DEPRECATED.** The action has been moved to [the keep-network/ci repository](https://github.com/keep-network/ci/tree/main/actions/run-workflow)!
+
 This is a GitHub Action that runs an external workflow.
 
 ## Action Inputs


### PR DESCRIPTION
The actions that depend on the `keep-network/ci/config/config.json` file
have been moved to the `ci` repository to make updates of the CI cycle
easier to apply.